### PR TITLE
Bugfix/overrides

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -3,6 +3,7 @@ recipe: wordpress
 config:
   webroot: wp
   php: '7.4'
+  composer_version: 1
 
 services:
   node:

--- a/greg.php
+++ b/greg.php
@@ -6,7 +6,7 @@
  * Author: SiteCrafting
  * Author URI: https://www.sitecrafting.com/
  * Description: A de-coupled calendar solution for WordPress and Timber
- * Version: 0.4.0
+ * Version: 0.4.1
  * Requires PHP: 7.4
  */
 

--- a/test/unit/CalendarTest.php
+++ b/test/unit/CalendarTest.php
@@ -350,6 +350,63 @@ class CalendarTest extends BaseTest {
     ], $starts);
   }
 
+  public function test_recurrences_with_duplicate_start_time_overrides() {
+    // single event series:
+    // - 3/1 - 3/7 M/W/F 10am - 3pm, T/Th 11:30am - 3pm, Sat/Sun 11:30am - 4:30pm
+    $events = [
+      [
+        'start'                  => '2021-03-01 10:00:00',
+        'end'                    => '2021-03-01 15:00:00',
+        'title'                  => 'Three Times',
+        'recurrence'             => [
+          'until'                => '2021-03-07 15:00:00',
+          'frequency'            => 'Daily',
+          'exceptions'           => [],
+          'overrides'            => [
+            [
+              'start'            => '10:00:00',
+              'end'              => '15:00:00',
+              'BYDAY'            => ['MO', 'WE', 'FR'],
+            ],
+            [
+              'start'            => '11:30:00',
+              'end'              => '17:00:00',
+              'BYDAY'            => ['TU', 'TH'],
+            ],
+            [
+              'start'            => '11:30:00',
+              'end'              => '17:30:00',
+              'BYDAY'            => ['SA', 'SU'],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $calendar = new Calendar($events);
+
+    $starts = array_map(function(array $recurrence) {
+      return sprintf(
+        '%s - %s',
+        $recurrence['start'],
+        gmdate('H:i:s', strtotime($recurrence['end']))
+      );
+    }, $calendar->recurrences([
+      'earliest' => '2021-03-01',
+      'latest'   => '2021-03-10',
+    ]));
+
+    $this->assertEquals([
+      '2021-03-01 10:00:00 - 15:00:00',
+      '2021-03-02 11:30:00 - 17:00:00',
+      '2021-03-03 10:00:00 - 15:00:00',
+      '2021-03-04 11:30:00 - 17:00:00',
+      '2021-03-05 10:00:00 - 15:00:00',
+      '2021-03-06 11:30:00 - 17:30:00',
+      '2021-03-07 11:30:00 - 17:30:00',
+    ], $starts);
+  }
+
   public function test_recurrences_with_overrides_weekly() {
     // single event series:
     // - 3/1 - 3/7 M/W/F 10am - 3pm, Sat/Sun 11:30am - 4:30pm


### PR DESCRIPTION
#### Issue

The new BYDAY override functionality wasn't able to handle an event with multiple overrides with the same start time. Since the start time was being used as an array key, the last override with a duplicate start time always superseded any previous ones.

Example overrides which would trigger the issue:

- M, W, F 09:00 - 17:00
- T, Th 10:00 - 12:00
- S, Su 10:00 - 17:00

These conditions would result in overrides only existing for M, W, F and S, Su. The override for T, Th is wiped out by the S, Su override.

#### Solution

Instead of using just the start time as the key for values added to the `$override_durations`, this bugfix prefixes the time with the ISO-8601 numeric representation of the day of the week (e.g. date('N')).

Examples based on the above example overrides:

Old override keys:

- `09:00`
- `10:00`

New override keys:

- `1-09:00`
- `3-09:00`
- `5-09:00`
- `2-10:00`
- `4-10:00`
- `6-10:00`
- `7-10:00`

#### Impact

In theory there shouldn't be any negative impact on the user. The only impact is that overrides should work as expected when duplicate start times are present.

#### Considerations

I'm not 100% sure if this solution is the best possible approach to addressing this issue (i.e. most efficient) since it does involve nested `foreach` loops. However, I'm thinking that's a non-factor since in theory there should only ever be a max of 7 overrides per event (1 for each day of the week). But I'm curious to hear if there's a better or more elegant way to approach addressing this issue!

Also, a side note: when setting up Greg locally for development, I ended up needing to downgrade composer from the default version 2 to version 1 in order for composer dependencies to install. I've included that update to the landofile in this update.

#### Testing

All unit, static analysis, and coding standards tests are passing locally with this fix. I haven't added a unit test to test this specific case yet, but I'll circle back to that once the initial code review is in progress.

_**Edit**: Unit test with overlapping override start times added. Confirmed it fails when run against the current `main` branch and succeeds when run against this branch._
