### PR TITLE
Address EventQuery pagination issue

### DIFF
--- a/greg.php
+++ b/greg.php
@@ -6,7 +6,7 @@
  * Author: SiteCrafting
  * Author URI: https://www.sitecrafting.com/
  * Description: A de-coupled calendar solution for WordPress and Timber
- * Version: 0.4.1
+ * Version: 0.4.2
  * Requires PHP: 7.4
  */
 

--- a/src/EventQuery.php
+++ b/src/EventQuery.php
@@ -150,6 +150,8 @@ class EventQuery {
   public function params() : array {
     return array_merge([
       'post_type'  => 'greg_event',
+      // TODO: We should probably allow the user to pass pagination params in
+      'posts_per_page' => -1,
     ], $this->meta_clause(), $this->tax_clause());
   }
 


### PR DESCRIPTION
Update EventQuery params to get all events matching the meta & tax queries, instead of limiting based on the WP posts_per_page setting

#### Issue

When using `Greg\get_events` or `Greg\EventQuery`, the user is unable to pass in any pagination params which make it to the eventual call to `Timber::get_posts`. This means that the query is limited to the WP `posts_per_page` setting, instead of getting all events which match the meta and tax queries Greg builds out based on the params passed in.

As a result, the max number of events displayed will always be limited to the number defined in `posts_per_page`, with no option of increasing that number or paginating through additional events matching that query.

#### Solution

After talking to @akoziolsc, I've updated `Greg\EventQuery::params()` to always include `'posts_per_page' => -1` in the params array. This will result in `EventQuery` always returning **_all_** events which match the current query. This might end up being a temporary fix until we come up with a more robust strategy around params and pagination for Greg.

#### Impact

I believe this was the intended functionality, so I'm hoping the only impact is addressing a bug. Here's hoping!

#### Considerations

This may not be the best possible solution to this issue. In the future, we might want to address this a bit differently by doing something like:

- Allowing the user to pass in WP_Query params which are passed along to `Timber::get_posts`
- Exposing a filter to allow devs to manipulate the params array before it's used to query event posts
- Something else?

#### Testing

I'm not sure any test updates are required for this, but all ci/sniff/analyze tests passed.
