### PR TITLE
Timber version requirement downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Let's get one thing out of the way: Greg is **not** a drop-in replacement for Th
   * PHP >= 7.4
   * WordPress Core >= 5.5.1
   * [Timber 1](https://timber.github.io/docs/)
+    * If you need [Timber 2](https://timber.github.io/docs/v2/) support, use Greg v0.4.x
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Let's get one thing out of the way: Greg is **not** a drop-in replacement for Th
 
   * PHP >= 7.4
   * WordPress Core >= 5.5.1
-  * [Timber >= 2.0](https://timber.github.io/docs/v2/)
+  * [Timber 1](https://timber.github.io/docs/)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "wp-coding-standards/wpcs": "^2.3",
     "szepeviktor/phpstan-wordpress": "^0.6.5",
     "paulthewalton/acf-stubs": "^5.8.7",
-    "timber/timber": "2.x-dev"
+    "timber/timber": "^1.20"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18b5cb23871cd9ad4b9510fc1eccb899",
+    "content-hash": "969a9641a3438debe01e317c787cd28c",
     "packages": [
         {
             "name": "rlanvin/php-rrule",
@@ -53,6 +53,62 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "altorouter/altorouter",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dannyvankooten/AltoRouter.git",
+                "reference": "f6fede4f94ced7c22ba63a9b8af0bf2dc38e3cb2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dannyvankooten/AltoRouter/zipball/f6fede4f94ced7c22ba63a9b8af0bf2dc38e3cb2",
+                "reference": "f6fede4f94ced7c22ba63a9b8af0bf2dc38e3cb2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "phpunit/phpunit": "5.7.*",
+                "squizlabs/php_codesniffer": "3.4.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "AltoRouter.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Danny van Kooten",
+                    "email": "dannyvankooten@gmail.com",
+                    "homepage": "http://dannyvankooten.com/"
+                },
+                {
+                    "name": "Koen Punt",
+                    "homepage": "https://github.com/koenpunt"
+                },
+                {
+                    "name": "niahoo",
+                    "homepage": "https://github.com/niahoo"
+                }
+            ],
+            "description": "A lightning fast router for PHP",
+            "homepage": "https://github.com/dannyvankooten/AltoRouter",
+            "keywords": [
+                "lightweight",
+                "router",
+                "routing"
+            ],
+            "time": "2020-03-09T08:34:59+00:00"
+        },
         {
             "name": "composer/installers",
             "version": "v1.9.0",
@@ -2271,34 +2327,34 @@
         },
         {
             "name": "timber/timber",
-            "version": "2.x-dev",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/timber/timber.git",
-                "reference": "41f0d6f61c4121095c6dc810050fc93f85245e68"
+                "reference": "3ac8c7629656009b9e0d6d9e4ccda202aad3b8e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/timber/timber/zipball/41f0d6f61c4121095c6dc810050fc93f85245e68",
-                "reference": "41f0d6f61c4121095c6dc810050fc93f85245e68",
+                "url": "https://api.github.com/repos/timber/timber/zipball/3ac8c7629656009b9e0d6d9e4ccda202aad3b8e0",
+                "reference": "3ac8c7629656009b9e0d6d9e4ccda202aad3b8e0",
                 "shasum": ""
             },
             "require": {
-                "composer/installers": "~1.0",
-                "php": "^7.0",
-                "twig/cache-extension": "^1.5.0",
-                "twig/twig": "^2.10"
+                "composer/installers": "^1.0 || ^2.0",
+                "php": ">=5.3.0 || 7.*",
+                "twig/cache-extension": "^1.5",
+                "twig/twig": "^1.41 || ^2.10",
+                "upstatement/routes": "0.9.*"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "johnpbloch/wordpress": ">=5.4.0",
-                "php-stubs/wp-cli-stubs": "^2.2.0",
-                "phpunit/phpunit": "7.*",
+                "johnpbloch/wordpress": "*",
+                "phpunit/phpunit": "5.7.21 || 6.*",
                 "squizlabs/php_codesniffer": "3.*",
-                "szepeviktor/phpstan-wordpress": "^0.6.0",
                 "wp-coding-standards/wpcs": "^2.0",
                 "wpackagist-plugin/advanced-custom-fields": "5.*",
-                "wpackagist-plugin/co-authors-plus": "3.2.*|3.4.*"
+                "wpackagist-plugin/co-authors-plus": "3.2.* || 3.4.*",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "suggest": {
                 "satooshi/php-coveralls": "1.0.* for code coverage"
@@ -2333,7 +2389,7 @@
                 "timber",
                 "twig"
             ],
-            "time": "2020-11-24T18:18:39+00:00"
+            "time": "2022-06-22T19:42:09+00:00"
         },
         {
             "name": "twig/cache-extension",
@@ -2400,6 +2456,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "twig/cache-extra",
             "time": "2020-10-06T05:47:02+00:00"
         },
         {
@@ -2478,16 +2535,67 @@
             "time": "2020-11-27T13:05:37+00:00"
         },
         {
+            "name": "upstatement/routes",
+            "version": "0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Upstatement/routes.git",
+                "reference": "cac3c844ab824e4039fd26edbea5402415aa6d0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Upstatement/routes/zipball/cac3c844ab824e4039fd26edbea5402415aa6d0a",
+                "reference": "cac3c844ab824e4039fd26edbea5402415aa6d0a",
+                "shasum": ""
+            },
+            "require": {
+                "altorouter/altorouter": "^2.0.2",
+                "composer/installers": "^1.0 || ^2.0",
+                "php": ">=5.6.0|7.*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.16",
+                "satooshi/php-coveralls": "*",
+                "wp-cli/wp-cli": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Routes": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jared Novack",
+                    "email": "jared@upstatement.com",
+                    "homepage": "https://www.upstatement.com"
+                }
+            ],
+            "description": "Manage rewrites and routes in WordPress with this dead-simple plugin",
+            "homepage": "https://www.upstatement.com",
+            "keywords": [
+                "redirects",
+                "rewrite",
+                "routes",
+                "routing"
+            ],
+            "time": "2022-06-22T19:53:51+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -2576,8 +2684,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "rlanvin/php-rrule": 20,
-        "timber/timber": 20
+        "rlanvin/php-rrule": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/greg.php
+++ b/greg.php
@@ -6,7 +6,7 @@
  * Author: SiteCrafting
  * Author URI: https://www.sitecrafting.com/
  * Description: A de-coupled calendar solution for WordPress and Timber
- * Version: 0.4.2
+ * Version: 1.0.0
  * Requires PHP: 7.4
  */
 

--- a/greg.php
+++ b/greg.php
@@ -166,12 +166,12 @@ add_filter('greg/render/events-list.twig', function(array $data) : array {
 });
 
 add_filter('timber/locations', function(array $paths) {
-  $paths['greg'] = array_filter([
+  $greg_paths = array_filter([
     get_template_directory() . '/views/greg',
     GREG_PLUGIN_VIEW_PATH . '/twig',
   ], 'is_dir');
 
-  return $paths;
+  return array_merge($paths, $greg_paths);
 });
 
 add_filter('timber/twig', function(Environment $twig) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,5 +14,6 @@ parameters:
     - '#^Unsafe usage of new static\(\).$#'
     # We can't have strong typehints without union types :(
     - '#has no return typehint specified\.#'
-    - '#^Parameter \#1 \$term of static method Timber\\Timber::get_term\(\) expects int\|WP_Term\|null, array\|WP_Term given\.$#'
+    #- '#^Parameter \#1 \$term of static method Timber\\Timber::get_term\(\) expects int\|WP_Term\|null, array\|WP_Term given\.$#'
+    - '#^Parameter \#1 \$term of static method Timber\\Timber::get_term\(\) expects int\|object, array\|WP_Term given\.$#'
     - '#^Access to an undefined property Timber\\Term::\$slug.$#'

--- a/src/Event.php
+++ b/src/Event.php
@@ -201,17 +201,17 @@ class Event implements CoreInterface {
 
   /**
    * Gets meta fields for the given event post
-   * 
-	 * @param string $field_name
-	 * @return mixed
-	 */
-	public function meta( $field_name = null ) {
-		if ( $field_name === null ) {
-			//on the off-chance the field is actually named meta
-			$field_name = 'meta';
-		}
-		return $this->post->meta($field_name);
-	}
+   *
+   * @param string $field_name
+   * @return mixed
+   */
+  public function meta( $field_name = null ) {
+    if ( $field_name === null ) {
+        // on the off-chance the field is actually named meta
+        $field_name = 'meta';
+    }
+      return $this->post->meta($field_name);
+  }
 
 
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -199,6 +199,20 @@ class Event implements CoreInterface {
     return isset($this->post->$field);
   }
 
+  /**
+   * Gets meta fields for the given event post
+   * 
+	 * @param string $field_name
+	 * @return mixed
+	 */
+	public function meta( $field_name = null ) {
+		if ( $field_name === null ) {
+			//on the off-chance the field is actually named meta
+			$field_name = 'meta';
+		}
+		return $this->post->meta($field_name);
+	}
+
 
 
   /* API METHODS */

--- a/src/api.php
+++ b/src/api.php
@@ -117,13 +117,13 @@ function get_events(array $params = []) {
   // Unless recurrence expansion is explicitly disabled, expand each
   // (potentially) recurring event into its comprising recurrences.
   if ($params['expand_recurrences'] ?? true) {
-    $events      = array_map([Event::class, 'post_to_calendar_series'], $events->to_array());
+    $events      = array_map([Event::class, 'post_to_calendar_series'], $events);
     $calendar    = new Calendar($events);
     $constraints = $query->recurrence_constraints();
 
     return array_map([Event::class, 'from_assoc'], $calendar->recurrences($constraints));
   } else {
-    return array_map([Event::class, 'from_post'], $events->to_array());
+    return array_map([Event::class, 'from_post'], $events);
   }
 }
 
@@ -216,7 +216,8 @@ function event_category() {
 
   if (!$ident) {
     // Return the current term, if there is one.
-    return Timber::get_term();
+    $current_term = Timber::get_term(get_queried_object_id());
+    return $current_term && is_a($current_term, 'Timber\Term') ? $current_term : false;
   }
 
   $field   = is_int($ident) ? 'id' : 'slug';
@@ -226,7 +227,9 @@ function event_category() {
     return false;
   }
 
-  return Timber::get_term($wp_term);
+  $timber_term = Timber::get_term($wp_term);
+  
+  return $timber_term && is_a($timber_term, 'Timber\Term') ? $timber_term : false;
 }
 
 /**

--- a/src/api.php
+++ b/src/api.php
@@ -216,6 +216,10 @@ function event_category() {
 
   if (!$ident) {
     // Return the current term, if there is one.
+    $queried_object_id = get_queried_object_id();
+    if (!$queried_object_id) {
+      return false;
+    }
     $current_term = Timber::get_term(get_queried_object_id(), 'greg_event_category');
     return $current_term && is_a($current_term, 'Timber\Term') ? $current_term : false;
   }

--- a/src/api.php
+++ b/src/api.php
@@ -216,7 +216,7 @@ function event_category() {
 
   if (!$ident) {
     // Return the current term, if there is one.
-    $current_term = Timber::get_term(get_queried_object_id());
+    $current_term = Timber::get_term(get_queried_object_id(), 'greg_event_category');
     return $current_term && is_a($current_term, 'Timber\Term') ? $current_term : false;
   }
 
@@ -228,7 +228,7 @@ function event_category() {
   }
 
   $timber_term = Timber::get_term($wp_term);
-  
+
   return $timber_term && is_a($timber_term, 'Timber\Term') ? $timber_term : false;
 }
 


### PR DESCRIPTION
The official release of Timber 2 is taking much longer than anticipated, and until that happens we consider the Timber 2 branch to be a bit unstable to rely on in production. Because of this, we're updating Greg to require Timber 1 instead of Timber 2. This PR makes the necessary updates to implement this change.

Once Timber 2 is officially released and stable, reverting these changes should be fairly simple.